### PR TITLE
Update flow_chart.dart

### DIFF
--- a/lib/src/flow_chart.dart
+++ b/lib/src/flow_chart.dart
@@ -78,13 +78,16 @@ class _FlowChartState extends State<FlowChart> {
   Widget build(BuildContext context) {
     /// get dashboard position after first frame is drawn
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      final object = (context.findRenderObject() as RenderBox);
-      final translation = object.getTransformTo(null).getTranslation();
-      final Size size = object.semanticBounds.size;
-      Offset position = Offset(translation.x, translation.y);
+if (mounted) {
+  final object = (context.findRenderObject() as RenderBox);
+  final translation = object.getTransformTo(null).getTranslation();
+  final Size size = object.semanticBounds.size;
+  Offset position = Offset(translation.x, translation.y);
 
-      widget.dashboard.setDashboardSize(size);
-      widget.dashboard.setDashboardPosition(position);
+  widget.dashboard.setDashboardSize(size);
+  widget.dashboard.setDashboardPosition(position);
+}
+
     });
 
     GlobalKey gridKey = GlobalKey();


### PR DESCRIPTION
 error when attempting to input text into an object in the flutter_flow_chart package. The error message indicates that the findRenderObject method was called for an element that is in the "DEFUNCT" state, which means it is no longer part of the tree.

To fix this error, you will need to make sure that the element you are trying to input text into is active and part of the tree. One way to do this is to guard the call to findRenderObject with a check for the mounted state of the element

https://app.bountysource.com/issues/115027090-text-editor-bug-crash