### PR TITLE
New feature: addElement() at custom position

### DIFF
--- a/lib/src/dashboard.dart
+++ b/lib/src/dashboard.dart
@@ -164,12 +164,12 @@ class Dashboard extends ChangeNotifier {
   }
 
   /// add a [FlowElement] to the dashboard
-  void addElement(FlowElement element, {bool notify = true}) {
+  void addElement(FlowElement element, {bool notify = true, int? position}) {
     if (element.id.isEmpty) {
       element.id = const Uuid().v4();
     }
     element.setScale(1, gridBackgroundParams.scale);
-    elements.add(element);
+    elements.insert(position ?? elements.length, element);
     if (notify) {
       notifyListeners();
     }


### PR DESCRIPTION
## Description

Allow inserting elements with custom order.
    
In order to allow more flexibility for the consumer, add an optional "position" parameter to addElement(); if not specified, the element will be added to the last position as before.

An example use case is being able to add an element to the bottom of the stack instead of the top. Another would be allowing reverse z-order, like new elements always go below the exiting ones.

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
